### PR TITLE
Update backend to support image size/aspect ratio selection

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -29,12 +29,19 @@ app.post('/api/describe', async (req, res) => {
 app.post('/api/transform', async (req, res) =>{
     const description = req.body.imageDescription;
     const style = req.body.imageStyle;
+    const aspectRatio = req.body.imageAspectRatio;
+    const aspectRatioSizes = new Map([
+        ['square', '1024x1024'],
+        ['landscape', '1792x1024'],
+        ['portrait', '1024x1792']
+    ]);
+    const imageSize = aspectRatioSizes.get(aspectRatio);
     const imagePrompt = `Create an image that matches the following description:
     ${description}. The image is created in a(n) ${style} style.`;
     // console.log("Original prompt", imagePrompt);
 
     // Pass imagePrompt to OpenAI DALL-E-3
-    const transformedImage = await transformImage(imagePrompt);
+    const transformedImage = await transformImage(imagePrompt, imageSize);
     // console.log("New image response: ", transformedImage);
 
     // return image URL

--- a/backend/openai/agent.js
+++ b/backend/openai/agent.js
@@ -27,10 +27,11 @@ export async function describeImage(imageURL){
     return res;
 }
 
-export async function transformImage(imagePrompt){
+export async function transformImage(imagePrompt, imageSize){
     const res = await openai.images.generate({
         model: "dall-e-3",
         style: "vivid",
+        size: imageSize,
         prompt: imagePrompt,
         response_format: "b64_json",
     });


### PR DESCRIPTION
This fixes #18 

Summary
---
Currently, the backend generates **square (1024x1024)** images by default.
To support #10 , I made the following updates to the backend:
**backend/openai/agent.js - transformImage()**:
- added **imageSize** formal parameter:
- added explicit size selection to [OpenAI Image Generations call](https://platform.openai.com/docs/guides/images/generations):
```js
    const res = await openai.images.generate({
        model: "dall-e-3",
        style: "vivid",
        size: imageSize,
        prompt: imagePrompt,
        response_format: "b64_json",
    });
```
**backend/app.js - POST /api/transform**:
- Added an imageAspectRatio body parameter
- Added a map of aspect ratio sizes based on the [available size values for dall-e-3](https://platform.openai.com/docs/api-reference/images/create#images-create-size)

Required Frontend Changes
---
Calls to the `/api/transform` endpoint **must also pass** an **imageAspectRatio** value in the payload:

### Valid values
| imageAspectRatio value | corresponding size in backend |
| --- | --- |
| "square" | "1024x1024"|
| "landscape" | "1792x1024" |
| "portrait" | "1024x1792" |

### Partial Example Call
- Assume `imageDescription` and `imageStyle` are already defined
- If the user selects a button on the frontend that says "landscape", the resulting POST call to **/api/transform** would look like this:
```js
res = await fetch("http://localhost:4242/api/transform", {
	method: "POST",
	headers : {
		"Content-Type" : "application/json"
	},
	body: JSON.stringify({
		imageDescription: imageDescription,
		imageStyle: imageStyle,
                imageAspectRatio: "landscape"
	})
});
```