### PR TITLE
[ENHANCEMENT] Add support for Azure OpenAI Service

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,8 +5,12 @@ import { describeImage, transformImage } from "./openai/agent.js";
 import { readFileSync } from "node:fs";
 const app = express();
 app.use(express.json());
-app.use(cors());
-
+// CORS configuration
+app.use(cors({
+    origin: process.env.CANVA_APP_ORIGIN,
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    headers: ['Content-Type', 'Authorization']
+  }));
 // Health probe endpoint
 app.get('/', (req, res) => {
     res.send({ "status": "ready" });

--- a/backend/openai/agent.js
+++ b/backend/openai/agent.js
@@ -1,16 +1,32 @@
 import "dotenv/config.js";
-import OpenAI from "openai";
+import { OpenAI, AzureOpenAI } from "openai";
 
-const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY
-});
+// setup OpenAI client (OpenAI or Azure OpenAI)
+// apiVersion required for AzureOpenAI, refer to 
+// For AzureOpenAI, deployment is not a requirement, but you must use the appropriate deployment name as the 'model' property in the endpoint calls
+const apiVersion = "2024-05-01-preview";
+const client = (process.env.AOAI_KEY) ? new AzureOpenAI({ apiKey: process.env.AOAI_KEY, apiVersion: apiVersion, endpoint: process.env.AOAI_ENDPOINT }) : new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Deployment (model) names on Azure OpenAI Service (as of openai Version 4.52.7)
+const describingDeploymentName = "omni";
+const imageGenerationDeploymentName = "imageGeneration";
+
+// Model names on OpenAI API (as of openai Version 4.52.7)
+const describeModelName = "gpt-4o";
+const imageModelName = "dall-e-3";
+
+const textModel = (client instanceof AzureOpenAI) ? describingDeploymentName : describeModelName;
+const imageModel = (client instanceof AzureOpenAI) ? imageGenerationDeploymentName : imageModelName;
 
 const describePrompt = `Return a description of this image that can be used to accurately recreate the image. 
                         Do not include references to any style the image might have.
                         Start your description with 'The image depicts'`;
 export async function describeImage(imageURL) {
-    const res = await openai.chat.completions.create({
-        model: "gpt-4o",
+    (client instanceof AzureOpenAI) ?
+        console.log('Azure Deployment called') :
+        console.log("OpenAI API called");
+    const res = await client.chat.completions.create({
+        model: textModel,
         max_tokens: 200,
         messages: [
             {
@@ -32,8 +48,11 @@ export async function describeImage(imageURL) {
 }
 
 export async function transformImage(imagePrompt, imageSize) {
-    const res = await openai.images.generate({
-        model: "dall-e-3",
+    (client instanceof AzureOpenAI) ?
+    console.log('Azure Deployment called') :
+    console.log("OpenAI API called");
+    const res = await client.images.generate({
+        model: imageModel,
         style: "vivid",
         size: imageSize,
         prompt: imagePrompt,

--- a/backend/openai/agent.js
+++ b/backend/openai/agent.js
@@ -7,6 +7,11 @@ import { OpenAI, AzureOpenAI } from "openai";
 const apiVersion = "2024-05-01-preview";
 const client = (process.env.AOAI_KEY) ? new AzureOpenAI({ apiKey: process.env.AOAI_KEY, apiVersion: apiVersion, endpoint: process.env.AOAI_ENDPOINT }) : new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+function whatClient(){
+    (client instanceof AzureOpenAI) ?
+    console.log('Azure Deployment called') :
+    console.log("OpenAI API called");
+}
 // Deployment (model) names on Azure OpenAI Service (as of openai Version 4.52.7)
 const describingDeploymentName = "omni";
 const imageGenerationDeploymentName = "imageGeneration";
@@ -22,9 +27,7 @@ const describePrompt = `Return a description of this image that can be used to a
                         Do not include references to any style the image might have.
                         Start your description with 'The image depicts'`;
 export async function describeImage(imageURL) {
-    (client instanceof AzureOpenAI) ?
-        console.log('Azure Deployment called') :
-        console.log("OpenAI API called");
+    whatClient();
     const res = await client.chat.completions.create({
         model: textModel,
         max_tokens: 200,
@@ -48,9 +51,7 @@ export async function describeImage(imageURL) {
 }
 
 export async function transformImage(imagePrompt, imageSize) {
-    (client instanceof AzureOpenAI) ?
-    console.log('Azure Deployment called') :
-    console.log("OpenAI API called");
+    whatClient();
     const res = await client.images.generate({
         model: imageModel,
         style: "vivid",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5,10 +5,23 @@
   "packages": {
     "": {
       "dependencies": {
+        "@azure/openai": "^2.0.0-beta.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "openai": "^4.52.7"
+      }
+    },
+    "node_modules/@azure/openai": {
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@azure/openai/-/openai-2.0.0-beta.1.tgz",
+      "integrity": "sha512-SMcGMbhv8gYiTvmv2aKlkDAW0sI5pjGW5KyC94DTAYgpZS7eK+B1WpCfuJLzVaLxbYZXYWTsmd+dCsS4rXJ9+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -943,6 +956,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@azure/openai": "^2.0.0-beta.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",


### PR DESCRIPTION
This fixes #39 

## Summary
These changes correspond to `v5` of the backend image (current deployment has `v3` as of this PR).
This adds support for the [AzureOpenAI](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/openai/openai/MIGRATION.md#constructing-the-client) object from `openai` node package (`@azure/openai` is deprecated).

### What should my `.env` file look like?
As of this change, a `backend/.env` file should look like this:
```.env
# OpenAI API Key
OPENAI_API_KEY=<apiKey>
# Azure OpenAI Service Endpoint (find in Azure OpenAI deployment settings page)
AOAI_ENDPOINT=<Azure-OpenAI-Service-Endpoint>
# Azure OpenAI Service Endpoint Key (similar to API Key, find in Azure OpenAI deployment settings page)
AOAI_KEY=<Azure-OpenAI-Service-Key>
# Set NODE_ENV to `test` to use fake responses when DALL-E functionality doesn't need to be tested (e.g, testing UI changes)
# Set NODE_ENV to `production` for deployment
NODE_ENV=production
# Canva App origin URL for CORS settings
CANVA_APP_ORIGIN=<Canva-SDK-App-Origin>
```

## Use OpenAI API endpoints or Azure OpenAI?
The updated backend first checks for the **process.env.AOAI_KEY** (OpenAI API Key equivalent) first.
If `process.env.AOAI_KEY` is defined, then the backend attempts to create an `AzureOpenAI` instance.
If `process.env.AOAI_KEY` is undefined, then the backend will attempt to create an `OpenAI` instance.

In other words, if **both** `AOAI_KEY` and `OPENAI_API_KEY` are defined in `backend/.env`, the backend will create an **AzureOpenAI** instance